### PR TITLE
stop logging every scanned vaccine card

### DIFF
--- a/app/src/main/java/ca/bc/gov/vaxcheck/barcodeanalyzer/BarcodeAnalyzer.kt
+++ b/app/src/main/java/ca/bc/gov/vaxcheck/barcodeanalyzer/BarcodeAnalyzer.kt
@@ -1,6 +1,5 @@
 package ca.bc.gov.vaxcheck.barcodeanalyzer
 
-import android.util.Log
 import androidx.camera.core.ExperimentalGetImage
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.ImageProxy
@@ -37,7 +36,6 @@ class BarcodeAnalyzer(private val listener: ScanningResultListener) : ImageAnaly
                         }
                         val rawValue = barcode?.rawValue
                         rawValue?.let {
-                            Log.d("Barcode", it)
                             listener.onScanned(it)
                             isScanning = false
                         }


### PR DESCRIPTION
As per Section 2.1 of the [app's privacy policy](https://www2.gov.bc.ca/gov/content/covid-19/vaccine/proof/businesses#app-privacy-policy),

> The BC Vaccine Card Verifier reads and displays the information presented in the QR code within the camera's view.
>
> The result of this processing is not stored on the verification device nor transmitted outside of the BC Vaccine Card Verifier.

However, the result of every scan is logged into logcat (the full SHC URI string).  Considering that each vaccine card contains PII (full name, date of birth, and COVID vaccination history), this info should not be logged. The owner of the phone (and anyone else able to activate developer options on the phone) can view these logs, as logcat is persisted on the device for some time.