### PR TITLE
feat: case-insensitive shc protocol prefix removal

### DIFF
--- a/app/src/main/java/ca/bc/gov/vaxcheck/utils/SHCDecoder.kt
+++ b/app/src/main/java/ca/bc/gov/vaxcheck/utils/SHCDecoder.kt
@@ -257,7 +257,7 @@ class SHCDecoder {
      */
     private fun shcUriToBase64(shcUri: String): String {
         // REMOVE SHC PREFIX
-        val encodedBase64 = shcUri.removePrefix("shc:/")
+        val encodedBase64 = shcUri.lowercase().removePrefix("shc:/")
 
         val size = (encodedBase64.length - 1)
 


### PR DESCRIPTION
Previous PR (against main): bcgov/BCVAX-Android#28
iOS counterpart: bcgov/BCVAX-iOS#10

> Some QR code generators / display apps can only encode the SHC token efficiently if shc:/ is in upper case, this ensures the validator app can read these encoded QR codes.

Note: Because only the shc:/ prefix is alphabetical, and the rest of the URI consists of digits, converting the entire string to lowercase should be safe

